### PR TITLE
Add parameter to skip SSH NSG rule

### DIFF
--- a/edgeDeploy.json
+++ b/edgeDeploy.json
@@ -119,7 +119,7 @@
       "name": "[variables('networkSecurityGroupName')]",
       "location": "[resourceGroup().location]",
       "properties": {
-        "securityRules": "[if(parameters('allowSsh'), variables('sshRule'), variables('noRule')]"
+        "securityRules": "[if(parameters('allowSsh'), variables('sshRule'), variables('noRule'))]"
       }
     },
     {

--- a/edgeDeploy.json
+++ b/edgeDeploy.json
@@ -34,13 +34,6 @@
         "description": "The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version."
       }
     },
-    "location": {
-      "type": "string",
-      "defaultValue": "[resourceGroup().location]",
-      "metadata": {
-        "description": "Location for all resources."
-      }
-    },
     "authenticationType": {
       "type": "string",
       "defaultValue": "sshPublicKey",
@@ -90,7 +83,7 @@
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
-      "location": "[parameters('location')]",
+      "location": "[resourceGroup().location]",
       "properties": {
         "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
         "dnsSettings": {
@@ -103,7 +96,7 @@
       "type": "Microsoft.Network/networkSecurityGroups",
       "apiVersion": "2019-08-01",
       "name": "[variables('networkSecurityGroupName')]",
-      "location": "[parameters('location')]",
+      "location": "[resourceGroup().location]",
       "properties": {
         "securityRules": [{
           "name": "default-allow-22",
@@ -124,7 +117,7 @@
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
-      "location": "[parameters('location')]",
+      "location": "[resourceGroup().location]",
       "dependsOn": [
         "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
       ],
@@ -149,7 +142,7 @@
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
-      "location": "[parameters('location')]",
+      "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
@@ -173,7 +166,7 @@
       "apiVersion": "2016-04-30-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
-      "location": "[parameters('location')]",
+      "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
       ],

--- a/edgeDeploy.json
+++ b/edgeDeploy.json
@@ -50,6 +50,13 @@
       "metadata": {
         "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
       }
+    },
+    "allowSsh": {
+      "type": "bool",
+      "defaultValue": "true",
+      "metadata": {
+        "description": "Allow SSH traffic through the firewall"
+      }
     }
   },
   "variables": {
@@ -77,7 +84,21 @@
       }
     },
     "dcs": "[parameters('deviceConnectionString')]",
-    "networkSecurityGroupName": "[concat('nsg-', uniquestring(parameters('dnsLabelPrefix')))]"
+    "networkSecurityGroupName": "[concat('nsg-', uniquestring(parameters('dnsLabelPrefix')))]",
+    "sshRule": [{
+      "name": "default-allow-22",
+      "properties": {
+        "priority": 1000,
+        "access": "Allow",
+        "direction": "Inbound",
+        "destinationPortRange": "22",
+        "protocol": "Tcp",
+        "sourceAddressPrefix": "*",
+        "sourcePortRange": "*",
+        "destinationAddressPrefix": "*"
+      }
+    }],
+    "noRule": []
   },
   "resources": [{
       "apiVersion": "2015-06-15",
@@ -98,19 +119,7 @@
       "name": "[variables('networkSecurityGroupName')]",
       "location": "[resourceGroup().location]",
       "properties": {
-        "securityRules": [{
-          "name": "default-allow-22",
-          "properties": {
-            "priority": 1000,
-            "access": "Allow",
-            "direction": "Inbound",
-            "destinationPortRange": "22",
-            "protocol": "Tcp",
-            "sourceAddressPrefix": "*",
-            "sourcePortRange": "*",
-            "destinationAddressPrefix": "*"
-          }
-        }]
+        "securityRules": "[if(parameters('allowSsh'), variables('sshRule'), variables('noRule')]"
       }
     },
     {


### PR DESCRIPTION
This change:
- Adds the "allowSsh" parameter to the ARM deployment script. It is true by default, so if you leave it alone the script's behavior will not change. But if you set it to false, it will skip creating an allow rule for port 22 in the network security group. This pattern is similar to creating Azure VMs in general--the portal and Azure CLI enable this rule by default but allow you to disable it.
- Removes the "location" parameter, which is redundant because you already have to specify the resource group, both in the portal and in the `az deployment group create` command.

I tested the "allowSsh" variable in the portal and with the `az` CLI, using both values, and the NSG rule is generated or skipped as expected.