### PR TITLE
allowSSH of type bool but value of type string

### DIFF
--- a/edgeDeploy.json
+++ b/edgeDeploy.json
@@ -53,7 +53,7 @@
     },
     "allowSsh": {
       "type": "bool",
-      "defaultValue": "true",
+      "defaultValue": true,
       "metadata": {
         "description": "Allow SSH traffic through the firewall"
       }


### PR DESCRIPTION
allowSSH value was set to type bool, but the defaultValue was of type string which was causing an error.